### PR TITLE
Add function for create, find and delete refresh_tokens on database

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -9,6 +9,7 @@ const config = {
         host: "127.0.0.1"
     },
     access_token_secret: "e6307cb3ccf280393faf3c2bcf7284677a2e84433612edb4eef93ffbcd1a4fbb3c40961749bf038884d6d9a67d6cc8965d43f950e3a9e5d9ed4b7d2ec5ec5302",
+    refresh_token_secret: "09fee220c283d73eb387cbe838ea5ce5786e89e086179f43b388ef9b85c2dbd7bd42bde8172fe7f4d3acfd7c6d7722ea35c5ccdb5ffaa7d5d0d492127d0ff5f3",
     captcha_secretkey: "6LcaKtIZAAAAAMle0f8kTa0hj2Auf9R9pqzOxaF6"
 }
 

--- a/config.js.example
+++ b/config.js.example
@@ -10,7 +10,8 @@ const config = {
     },
     access_token_secret: "e6307cb3ccf280393faf3c2bcf7284677a2e84433612edb4eef93ffbcd1a4fbb3c40961749bf038884d6d9a67d6cc8965d43f950e3a9e5d9ed4b7d2ec5ec5302",
     refresh_token_secret: "09fee220c283d73eb387cbe838ea5ce5786e89e086179f43b388ef9b85c2dbd7bd42bde8172fe7f4d3acfd7c6d7722ea35c5ccdb5ffaa7d5d0d492127d0ff5f3",
-    captcha_secretkey: "6LcaKtIZAAAAAMle0f8kTa0hj2Auf9R9pqzOxaF6"
+    captcha_secretkey: "6LcaKtIZAAAAAMle0f8kTa0hj2Auf9R9pqzOxaF6",
+    access_token_expire_in: '900s'
 }
 
 module.exports = config;

--- a/public/login.html
+++ b/public/login.html
@@ -59,9 +59,15 @@
                 method: 'post',
                 body: JSON.stringify(data)
             })
-                .then(response => response.text())
-                .then(text => showResult(text))
-                .catch(error => showResult(error));
+                .then(response => response.json())
+                .then(response => {
+                    const token = response.access_token;
+                    if (!token) {
+                        return showResult(response.message);
+                    }
+                    window.alert('Successfully logged in!');
+                    console.log(response);
+                });
         }
 
         function showResult(text) {

--- a/routes/employee_auth.js
+++ b/routes/employee_auth.js
@@ -97,7 +97,7 @@ const create_employee = async (employee) => {
 
 // Function which creates access token
 const create_access_token = (existing_employee) => {
-    const access_token = jwt.sign({ id: existing_employee.employee_id, admin: existing_employee.employee_is_admin }, config.access_token_secret, { expiresIn: '30s' });
+    const access_token = jwt.sign({ id: existing_employee.employee_id, admin: existing_employee.employee_is_admin }, config.access_token_secret, { expiresIn: config.access_token_expire_in });
     return access_token;
 }
 

--- a/routes/employee_auth.js
+++ b/routes/employee_auth.js
@@ -95,6 +95,45 @@ const create_employee = async (employee) => {
     }
 }
 
+// Function which creates access token
+const create_access_token = (existing_employee) => {
+    const access_token = jwt.sign({ id: existing_employee.employee_id, admin: existing_employee.employee_is_admin }, config.access_token_secret, { expiresIn: '30s' });
+    return access_token;
+}
+
+// Function which adds refresh token to database
+const add_refresh_token = async (refresh_token) => {
+    try {
+        const TABLE_NAME = 'refresh_tokens';
+        await knex(TABLE_NAME).insert(refresh_token);
+    } catch (err) {
+        return err;
+    }
+}
+
+// Function which finds refresh token on database
+const find_refresh_token = async (refresh_token) => {
+    try {
+        const TABLE_NAME = 'refresh_tokens';
+        const COLUMN_NAME = 'refresh_token';
+        const matching_refresh_tokens = await knex(TABLE_NAME).where(COLUMN_NAME, refresh_token).select();
+        return matching_refresh_tokens[0];
+    } catch (err) {
+        return null;
+    }
+}
+
+// Function which delete refresh token on database
+const delete_refresh_token = async (refresh_token) => {
+    try {
+        const TABLE_NAME = 'refresh_tokens';
+        const COLUMN_NAME = 'refresh_token';
+        await knex(TABLE_NAME).where(COLUMN_NAME, refresh_token).delete();
+    } catch (err) {
+        return err;
+    }
+}
+
 const register = async (req, res) => {
     try {
 
@@ -167,12 +206,34 @@ const login = async (req, res) => {
         if (!(await bcryt.compare(req.body.password, existing_employee.employee_password_hash)))
             return res.json({ message: "Please review your credentials and try again!" })
 
-        const token = jwt.sign({ id: existing_employee.employee_id, admin: existing_employee.employee_is_admin }, config.access_token_secret);
-        console.log(token);
-        res.header("auth-token", token).send({ "token": token });
+        const access_token = create_access_token(existing_employee);
+        const refresh_token = jwt.sign({ id: existing_employee.employee_id, admin: existing_employee.employee_is_admin }, config.refresh_token_secret);
+        await add_refresh_token({ employee_id: existing_employee.employee_id, refresh_token: refresh_token });
+
+        res.json({ "access_token": access_token, "refresh_token": refresh_token });
     } catch (err) {
         return res.status(500).json({ message: err.message });
     }
+}
+
+const logout = async (req, res) => {
+    await delete_refresh_token(req.body.refresh_token);
+    res.sendStatus(204);
+}
+
+const generate_new_token = async (req, res) => {
+    const refresh_token = req.body.refresh_token;
+    if (!refresh_token) return res.sendStatus(401);
+
+    const existing_refresh_token = await find_refresh_token(refresh_token);
+    if (!existing_refresh_token) return res.sendStatus(403);
+
+    jwt.verify(refresh_token, config.refresh_token_secret, (err, existing_employee) => {
+        if (err) return res.sendStatus(403);
+        const access_token = create_access_token(existing_employee);
+        res.json({ "access_token": access_token });
+    });
+
 }
 
 router.get('/', authenticate_token, async (req, res) => {
@@ -184,8 +245,12 @@ router.get('/', authenticate_token, async (req, res) => {
     }
 });
 
+router.post('/generate_new_token', generate_new_token);
+
 router.post('/register', authenticate_captcha, register);
 
 router.post('/login', authenticate_captcha, login);
+
+router.delete('/logout', logout);
 
 module.exports = router

--- a/server.js
+++ b/server.js
@@ -25,6 +25,12 @@ const
     work_orders = require('./routes/work_orders');
 
 app
+    .use((req, res, next) => {
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS,POST,PUT,DELETE");
+        res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization");
+        next();
+    })
     .use('/api-docs', swagger_ui.serve, swagger_ui.setup(swagger_document, swagger_options))
     .use(express.json())
     .use(express.urlencoded({ extended: false }))

--- a/test.rest
+++ b/test.rest
@@ -1,11 +1,27 @@
 @hostname = localhost
 @port = 8000
 @host = {{hostname}}:{{port}}
-@authorization = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTAyLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNjAyMjA0NjY5fQ.vU2_Vw295nSvq9pLixhIULUQm43YRcppq_H3jwPKxFk
+@authorization = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MDQwMjkxNjksImV4cCI6MTYwNDAyOTE5OX0.GS2hjAR48OUGbbGxx8Hv_J9u27rZGZ6fOxKqWvCTwdo
 
 
 GET http://{{host}}/products/4
 Authorization: Bearer {{authorization}}
+###
+
+POST http://{{host}}/auth/employee/generate_new_token
+Content-Type: application/json
+
+{
+    "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTAxLCJhZG1pbiI6ZmFsc2UsImlhdCI6MTYwNDM1NjA5MH0.muWzBFjyXuBNhSbdHEnQ0vUZsZk9G2TDZszk0CWTIuI"
+}
+###
+
+DELETE http://{{host}}/auth/employee/logout
+Content-Type: application/json
+
+{
+    "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTAxLCJhZG1pbiI6ZmFsc2UsImlhdCI6MTYwNDM1NjA5MH0.muWzBFjyXuBNhSbdHEnQ0vUZsZk9G2TDZszk0CWTIuI"
+}
 ###
 
 

--- a/test.rest
+++ b/test.rest
@@ -2,6 +2,7 @@
 @port = 8000
 @host = {{hostname}}:{{port}}
 @authorization = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MDQwMjkxNjksImV4cCI6MTYwNDAyOTE5OX0.GS2hjAR48OUGbbGxx8Hv_J9u27rZGZ6fOxKqWvCTwdo
+@refresh_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTAxLCJhZG1pbiI6ZmFsc2UsImlhdCI6MTYwNDUyMjY5OX0.oSbxGkyAiV5sySw29DiQhF2DEwVFxxI8FvasskpXuzU"
 
 
 GET http://{{host}}/products/4
@@ -12,7 +13,7 @@ POST http://{{host}}/auth/employee/generate_new_token
 Content-Type: application/json
 
 {
-    "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTAxLCJhZG1pbiI6ZmFsc2UsImlhdCI6MTYwNDM1NjA5MH0.muWzBFjyXuBNhSbdHEnQ0vUZsZk9G2TDZszk0CWTIuI"
+    "refresh_token": {{refresh_token}}
 }
 ###
 
@@ -20,7 +21,7 @@ DELETE http://{{host}}/auth/employee/logout
 Content-Type: application/json
 
 {
-    "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTAxLCJhZG1pbiI6ZmFsc2UsImlhdCI6MTYwNDM1NjA5MH0.muWzBFjyXuBNhSbdHEnQ0vUZsZk9G2TDZszk0CWTIuI"
+    "refresh_token": {{refresh_token}}
 }
 ###
 


### PR DESCRIPTION
# Description

Add function for create, find and delete refresh_tokens on database

Fixes # (issue)

employee_auth.js
- Create create_access_token function to generate access_token
- Create add_refresh_token, find_refresh_token, delete_refresh_token function to add, find and delete refresh_token on database
- Add generate_new_token route to generate new access_token
- Add logout route to destroy existing refresh_tokens

config.js.example
- Add refresh_token_secret

login.html
- Update fetch response 

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- Start server, PG database
- Go to http://localhost:8000/register.html and click button to create an account
- Go to http://localhost:8000/login.html and click button to login this account
- If browser tells you that you've logged in successfully, open the DevTool, copy the refresh_token and paste it to the req body 
  below 'POST http://{{host}}/auth/employee/generate_new_token' and 'DELETE http://{{host}}/auth/employee/logout' on test.rest
- For 'POST http://{{host}}/auth/employee/generate_new_token', if you send request you will see the new access_token returns 
  back
- For 'DELETE http://{{host}}/auth/employee/logout', if you send request you will see this refresh_token is removed from 
  database

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules